### PR TITLE
Graph dbs now deleted instead of stored in tmp location

### DIFF
--- a/scripts/changeGraphDatabase.sh
+++ b/scripts/changeGraphDatabase.sh
@@ -7,6 +7,7 @@ finalNeo4jDir="/var/lib/neo4j/data/databases"
 chmod 644 ${tmpNeo4jDir}/*
 chmod a+x ${tmpNeo4jDir}/schema/
 chown -R neo4j:adm ${tmpNeo4jDir}/
-mkdir -p ${finalNeo4jDir}/extra
-mv ${finalNeo4jDir}/graph.db ${finalNeo4jDir}/extra/
+## Existing graph database should either be archived already on S3 (final), or can otherwise be deleted (post-orthoinference, pre-biomodels).
+## Either way, safe to delete the graph database here.
+rm -r ${finalNeo4jDir}/graph.db
 mv ${tmpNeo4jDir} ${finalNeo4jDir}/


### PR DESCRIPTION
Very small PR that just allows changeGraphDatabase.sh to be run without needing to do anything else (ie. clear out the 'extra' folder where it was previously stored out of paranoia).

The post-orthoinference and the pre-biomodels  graph dbs will not be stored on S3, while the final one (post-diagram-converter) will be.